### PR TITLE
feat: Provide the initial setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+# Artifacts
+build/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,49 @@
+cmake_minimum_required(VERSION 3.14)
+project(funktions LANGUAGES CXX)
+
+option(BUILD_TESTS "Build test executable" OFF)
+
+add_library(${PROJECT_NAME} INTERFACE)
+
+add_library(rvarago::${PROJECT_NAME} ALIAS ${PROJECT_NAME})
+
+target_include_directories(${PROJECT_NAME}
+    INTERFACE
+        $<INSTALL_INTERFACE:include>
+        $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+)
+
+target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_17)
+
+# Tests
+
+if(BUILD_TESTS)
+    include(CTest)
+    add_subdirectory(tests)
+endif()
+
+# Installation
+
+include(GNUInstallDirs)
+
+# Generate the config file with the target
+install(TARGETS ${PROJECT_NAME}
+        EXPORT ${PROJECT_NAME}Config
+)
+
+install(DIRECTORY include/
+        DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}
+)
+
+# Make the target be importable from the installation directory
+install(EXPORT ${PROJECT_NAME}Config
+        DESTINATION ${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}
+        NAMESPACE rvarago::
+)
+
+# Make the target be importable from the build directory via package registry
+export(EXPORT ${PROJECT_NAME}Config
+       NAMESPACE rvarago::
+)
+
+export(PACKAGE ${PROJECT_NAME})

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,0 +1,20 @@
+strategy:
+  matrix:
+    linux:
+      imageName: 'ubuntu-18.04'
+    windows:
+      imageName: 'windows-2019'
+
+pool:
+  vmImage: $(imageName)
+
+steps:
+
+  - script: |
+      cmake . -DBUILD_TESTS=ON && cmake --build .
+    displayName: 'Build'
+
+  - script: |
+      ctest -VV .
+    displayName: 'Test'
+

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,0 +1,36 @@
+project(funktions_tests LANGUAGES CXX)
+
+include(FetchContent)
+
+FetchContent_Declare(
+        catch
+        GIT_REPOSITORY https://github.com/catchorg/Catch2.git
+        GIT_TAG        v2.12.4
+)
+FetchContent_MakeAvailable(catch)
+
+add_executable(${PROJECT_NAME}
+    main.cpp
+)
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(${PROJECT_NAME}
+        PRIVATE
+            -Wall -Wextra -Werror -ansi -pedantic
+    )
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    target_compile_options(${PROJECT_NAME}
+        PRIVATE
+            /Wall /W4
+    )
+else()
+    message("Unknown compiler... skipping configuration for warnings")
+endif()
+
+target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+        rvarago::funktions
+        Catch2::Catch2
+)
+
+add_test(${PROJECT_NAME} ${PROJECT_NAME})

--- a/tests/main.cpp
+++ b/tests/main.cpp
@@ -1,0 +1,6 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+TEST_CASE("ok") {
+  CHECK(1==1);
+}


### PR DESCRIPTION
*  feat: Set up basic scaffolding for a C++ project

This patch adds the following components:

* Build system: CMake
* Testing library: Catch2
* CI: Azure Pipelines

Notice that, due to simplicity, CMake (FetchContent) is used to
fetch Catch2, instead of a proper package manager.

* chore: gitignore: Ignore the 'build/' directory