### PR TITLE
feat: chain: Introduce 'operator>>' for functional composition 

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ A small C++17 set of utilities for functional composition.
 * [`fn_wrapper`](#fn_wrapper)
 * [`logical_and`](#logical_and)
 * [`logical_or`](#logical_or)
+* [`chain`](#chain)
 * [`predicates`](#predicates)
 
 ## <A name="fn_wrapper"/>`fn_wrapper`
@@ -51,6 +52,26 @@ auto const y = eq_2_or_6(x); // y = (x == 2) || (x == 6)
 ```
 
 [logical.h](include/funktions/logical.h)
+
+## <A name="chain"/>`chain`
+
+An overload for the `operator>>` that acts on two functions wrapped in `fn_wrapper`'s to produce a third function (their composition),
+which when invoked with a pack of arguments, forwards them to the first function and then applies its
+outcome into the second function.
+
+Example:
+
+```Cpp
+auto const plus_1 = [](auto const x) { return x + 1; };
+auto const square = [](auto const x) { return x * x; };
+
+auto const plus_1_then_square = fn(plus_1) >> square;
+
+auto const y = plus_1_then_square(x); // y = (x + 1) * (x + 1)
+```
+
+[chain.h](include/funktions/chain.h)
+
 
 ## <A name="predicates"/>`predicates`
 

--- a/include/funktions/chain.h
+++ b/include/funktions/chain.h
@@ -1,0 +1,30 @@
+#ifndef RVARAGO_FUNKTIONS_CHAIN_H
+#define RVARAGO_FUNKTIONS_CHAIN_H
+
+#include "funktions/fnwrapper.h"
+
+namespace rvarago::funktions::dsl {
+
+/**
+ * Wraps the functions _left_ and _right_ themselves wrapped in `fn_wrapper`'s to produce a third function (their
+ * composition), which when invoked with a pack of arguments, forwards them to _left_ and then applies its outcome into
+ * _right_.
+ * @tparam FunctionA type of the right function.
+ * @tparam FunctionB type of the left function.
+ * @param right first function wrapped in a fn_wrapper.
+ * @param left second function wrapped in a fn_wrapper.
+ * @return a new fn_wrapper that wraps the two function and computes their composition.
+ */
+template <typename FunctionA, typename FunctionB>
+constexpr auto operator>>(fn_wrapper<FunctionA> const left, fn_wrapper<FunctionB> const right) {
+    return fn_wrapper{[=](auto const &... args) { return right(left(args...)); }};
+}
+
+template <typename FunctionA, typename FunctionB>
+constexpr auto operator>>(fn_wrapper<FunctionA> const left, FunctionB const right) {
+    return left >> fn(right);
+}
+
+}
+
+#endif

--- a/include/funktions/logical.h
+++ b/include/funktions/logical.h
@@ -6,7 +6,7 @@
 namespace rvarago::funktions::dsl {
 
 /**
- * Wraps the the predicates _left_ and _right_ themselves wrapped in `fn_wrapper`'s to produce a third predicate, which
+ * Wraps the predicates _left_ and _right_ themselves wrapped in `fn_wrapper`'s to produce a third predicate, which
  * when invoked with a pack of arguments, forwards them to each predicate and computes the logical-and of their
  * outcomes.
  * @tparam PredicateA type of the right predicate.
@@ -26,7 +26,7 @@ constexpr auto operator&(fn_wrapper<PredicateA> const left, PredicateB const rig
 }
 
 /**
- * Wraps the the predicates _left_ and _right_ themselves wrapped in `fn_wrapper`'s to produce a third predicate, which
+ * Wraps the predicates _left_ and _right_ themselves wrapped in `fn_wrapper`'s to produce a third predicate, which
  * when invoked with a pack of arguments, forwards them to each predicate and computes the logical-or of their
  * outcomes.
  * @tparam PredicateA type of the right predicate.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -10,6 +10,7 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(catch)
 
 add_executable(${PROJECT_NAME}
+    chain_test.cpp
     fnwrapper_test.cpp
     logical_test.cpp
     predicates_test.cpp

--- a/tests/chain_test.cpp
+++ b/tests/chain_test.cpp
@@ -1,0 +1,39 @@
+#include <funktions/chain.h>
+
+#include <catch2/catch.hpp>
+
+#include <string>
+
+using namespace rvarago::funktions;
+using namespace rvarago::funktions::dsl;
+
+namespace {
+auto generate_random_ints() {
+    return GENERATE(take(100, random(-100, 100)));
+}
+}
+
+TEST_CASE("chain can compose two functions on integers", "[chain]") {
+    auto const plus_1 = [](auto const x) { return x + 1; };
+    auto const square = [](auto const x) { return x * x; };
+
+    auto const x = generate_random_ints();
+
+    auto const expected = [](auto const x) { return (x + 1) * (x + 1); }(x);
+    auto const got = (fn(plus_1) >> square)(x);
+    CHECK(expected == got);
+}
+
+TEST_CASE("chain can compose several functions where the domain of the first function does not need to match the "
+          "co-domain of the last function",
+          "[chain]") {
+    auto const plus_1 = [](auto const x) { return x + 1; };
+    auto const square = [](auto const x) { return x * x; };
+    auto const to_string = [](auto const x) { return std::to_string(x); };
+
+    auto const x = generate_random_ints();
+
+    auto const expected = [](auto const x) { return std::to_string((x + 1) * (x + 1)); }(x);
+    auto const got = (fn(plus_1) >> square >> to_string)(x);
+    CHECK(expected == got);
+}

--- a/tests/fnwrapper_test.cpp
+++ b/tests/fnwrapper_test.cpp
@@ -18,5 +18,7 @@ TEST_CASE("fn_wrapper wraps a generic callable that can be later called", "[fn_w
     auto const x = generate_random_ints();
     auto const y = generate_random_ints();
 
-    CHECK(model_wrapped(x, y) == model(x, y));
+    auto const expected = model(x, y);
+    auto const got = model_wrapped(x, y);
+    CHECK(expected == got);
 }

--- a/tests/logical_test.cpp
+++ b/tests/logical_test.cpp
@@ -1,7 +1,6 @@
 #include <funktions/logical.h>
 
 #include <catch2/catch.hpp>
-#include <map>
 
 using namespace rvarago::funktions;
 using namespace rvarago::funktions::dsl;
@@ -10,7 +9,7 @@ TEST_CASE("fn_wrappers can be combined by logical-and's", "[logical]") {
     auto const gt_2 = [](auto const x) { return x > 2; };
     auto const lt_6 = [](auto const x) { return x < 6; };
 
-    auto const [input, expected_output] = GENERATE(table<int, bool>({
+    auto const [input, expected] = GENERATE(table<int, bool>({
         {0, false},
         {1, false},
         {2, false},
@@ -22,15 +21,15 @@ TEST_CASE("fn_wrappers can be combined by logical-and's", "[logical]") {
         {8, false},
     }));
 
-    auto const bt_2_6 = fn(gt_2) & lt_6;
-    CHECK(bt_2_6(input) == expected_output);
+    auto const got = (fn(gt_2) & lt_6)(input);
+    CHECK(expected == got);
 }
 
 TEST_CASE("fn_wrappers can be combined by logical-or's", "[logical]") {
     auto const eq_1 = [](auto const x) { return x == 1; };
     auto const eq_4 = [](auto const x) { return x == 4; };
 
-    auto const [input, expected_output] = GENERATE(table<int, bool>({
+    auto const [input, expected] = GENERATE(table<int, bool>({
         {0, false},
         {1, true},
         {2, false},
@@ -42,8 +41,8 @@ TEST_CASE("fn_wrappers can be combined by logical-or's", "[logical]") {
         {8, false},
     }));
 
-    auto const eq_1_or_4 = fn(eq_1) | eq_4;
-    CHECK(eq_1_or_4(input) == expected_output);
+    auto const got = (fn(eq_1) | eq_4)(input);
+    CHECK(expected == got);
 }
 
 TEST_CASE("fn_wrappers can be combined by logical-and's and logical-or's", "[logical]") {
@@ -51,7 +50,7 @@ TEST_CASE("fn_wrappers can be combined by logical-and's and logical-or's", "[log
     auto const lt_6 = [](auto const x) { return x < 6; };
     auto const eq_8 = [](auto const x) { return x == 8; };
 
-    auto const [input, expected_output] = GENERATE(table<int, bool>({
+    auto const [input, expected] = GENERATE(table<int, bool>({
         {0, false},
         {1, false},
         {2, false},
@@ -63,6 +62,6 @@ TEST_CASE("fn_wrappers can be combined by logical-and's and logical-or's", "[log
         {8, true},
     }));
 
-    auto const bt_2_6_or_eq_8 = fn(gt_2) & lt_6 | eq_8;
-    CHECK(bt_2_6_or_eq_8(input) == expected_output);
+    auto const got = (fn(gt_2) & lt_6 | eq_8)(input);
+    CHECK(expected == got);
 }

--- a/tests/predicates_test.cpp
+++ b/tests/predicates_test.cpp
@@ -30,7 +30,7 @@ TEMPLATE_TEST_CASE("eq(x)(y) is equivalent to x == y", "[predicates]", int, doub
     auto const expected = x == y;
     auto const got = eq(x)(y);
 
-    CHECK(got == expected);
+    CHECK(expected == got);
 }
 
 TEMPLATE_TEST_CASE("ne(x)(y) is equivalent to x != y", "[predicates]", int, double, std::string) {
@@ -40,5 +40,5 @@ TEMPLATE_TEST_CASE("ne(x)(y) is equivalent to x != y", "[predicates]", int, doub
     auto const expected = x != y;
     auto const got = ne(x)(y);
 
-    CHECK(got == expected);
+    CHECK(expected == got);
 }


### PR DESCRIPTION
This PR adds an overload for the operator>> that acts on two functions wrapped in fn_wrapper's and computes their composition, such that:

auto const f3 = f1 >> f2; // f3(x) == f2(f1(x))  