### PR TITLE
feat: Create an 'examples' project with complete use-cases

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,6 +2,7 @@ cmake_minimum_required(VERSION 3.14)
 project(funktions LANGUAGES CXX)
 
 option(BUILD_TESTS "Build test executable" OFF)
+option(BUILD_EXAMPLES "Build example executables" OFF)
 
 add_library(${PROJECT_NAME} INTERFACE)
 
@@ -20,6 +21,10 @@ target_compile_features(${PROJECT_NAME} INTERFACE cxx_std_17)
 if(BUILD_TESTS)
     include(CTest)
     add_subdirectory(tests)
+endif()
+
+if(BUILD_EXAMPLES)
+    add_subdirectory(examples)
 endif()
 
 # Installation

--- a/README.md
+++ b/README.md
@@ -2,6 +2,28 @@
 
 A small C++17 set of utilities for functional composition.
 
+```Cpp
+enum class status { Idle, Busy };
+
+struct device {
+    long id;
+    long vendor_id;
+    status current_status;
+};
+
+std::vector<device> const devices = fetch_all_devices();
+
+// Given a device d:
+//  d.vendor_id == 2 and d.current_status == status::Idle
+auto const query = fn(get_vendor_id) >> eq(2)
+                    & fn(get_current_status) >> eq(status::Idle);
+
+// 'fn', 'eq', '>>', and '&' are some of the utilities provided by
+// funktions to build fluent Domain-Specific Languages.
+
+auto const device = std::find_if(devices.begin(), devices.end(), query);
+```
+
 # Utilities
 
 * [`fn_wrapper`](#fn_wrapper)
@@ -87,3 +109,7 @@ Built-in operations:
 * `gt(x)(y) // y > x`
 
 [predicates.h](include/funktions/predicates.h)
+
+# Examples
+
+[device_validation.cpp](examples/device_validation.cpp)

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -11,10 +11,13 @@ pool:
 steps:
 
   - script: |
-      cmake . -DBUILD_TESTS=ON && cmake --build .
+      cmake . -DBUILD_TESTS=ON -DBUILD_EXAMPLES=ON && cmake --build .
     displayName: 'Build'
 
   - script: |
       ctest -VV .
     displayName: 'Test'
 
+  - script: |
+      cmake --build . --target funktions_examples_run
+    displayName: 'Examples'

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -1,0 +1,29 @@
+project(funktions_examples LANGUAGES CXX)
+
+add_executable(${PROJECT_NAME}
+    device_validation.cpp
+)
+
+if (CMAKE_CXX_COMPILER_ID MATCHES "GNU|Clang")
+    target_compile_options(${PROJECT_NAME}
+        PRIVATE
+            -Wall -Wextra -Werror -ansi -pedantic
+    )
+elseif (CMAKE_CXX_COMPILER_ID MATCHES "MSVC")
+    target_compile_options(${PROJECT_NAME}
+        PRIVATE
+            /Wall /W4
+    )
+else()
+    message("Unknown compiler... skipping configuration for warnings")
+endif()
+
+target_link_libraries(${PROJECT_NAME}
+    PRIVATE
+        rvarago::funktions
+)
+
+add_custom_target(${PROJECT_NAME}_run
+    COMMAND ${PROJECT_NAME}
+    DEPENDS ${PROJECT_NAME}
+)

--- a/examples/device_validation.cpp
+++ b/examples/device_validation.cpp
@@ -1,0 +1,52 @@
+#include <funktions/chain.h>
+#include <funktions/logical.h>
+#include <funktions/predicates.h>
+
+#include <algorithm>
+#include <cassert>
+#include <iostream>
+#include <vector>
+
+using namespace rvarago::funktions;
+using namespace rvarago::funktions::dsl;
+
+namespace {
+
+using identifier = long;
+using vendor_identifier = long;
+
+enum class status { Idle, Busy };
+
+struct device {
+    identifier id;
+    vendor_identifier vendor_id;
+    status current_status;
+};
+
+auto get_vendor_id(device const &d) -> vendor_identifier {
+    return d.vendor_id;
+}
+
+auto get_current_status(device const &d) -> status {
+    return d.current_status;
+}
+
+}
+
+int main(int, char *[]) {
+    auto const device_registry = std::vector<device>{
+        {identifier{1}, vendor_identifier{1}, status{status::Idle}},
+        {identifier{2}, vendor_identifier{1}, status{status::Busy}},
+        {identifier{3}, vendor_identifier{2}, status{status::Idle}},
+        {identifier{4}, vendor_identifier{2}, status{status::Busy}},
+    };
+
+    // Given a device d: d.vendor_id == 2 and d.current_status == status::Idle
+    auto const search_query = fn(get_vendor_id) >> eq(2) & fn(get_current_status) >> eq(status::Idle);
+
+    auto const device_found = std::find_if(device_registry.cbegin(), device_registry.cend(), search_query);
+
+    assert(device_found->id == 3);
+
+    std::cout << "Device ID: " << device_found->id << '\n';
+}


### PR DESCRIPTION
The examples project should be a collection of complete, yet simple, use-cases that would allow the user to have a better understanding about capabilities offered by funktions and how to get started.

Furthermore, the README.md was updated to provide a better overview and a link to the examples directory.