### PR TITLE
feat: Introduce curried-operations that wrap boolean checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,11 @@ These operations are already wrapped inside `fn_wrapper`'s to profit from logica
 
 Built-in operations:
 
-* `eq(x)(y) // y == x`
-* `ne(x)(y) // y != x`
-* `lt(x)(y) // y < x`
-* `gt(x)(y) // y > x`
+* `eq(x)(y)         // y == x`
+* `ne(x)(y)         // y != x`
+* `lt(x)(y)         // y < x`
+* `gt(x)(y)         // y > x`
+* `is_true()(y)     // y == true`
 
 [funktions/predicates.h](include/funktions/predicates.h)
 

--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ Built-in operations:
 * `lt(x)(y)         // y < x`
 * `gt(x)(y)         // y > x`
 * `is_true()(y)     // y == true`
+* `is_false()(y)    // y == false`
 
 [funktions/predicates.h](include/funktions/predicates.h)
 

--- a/examples/device_validation.cpp
+++ b/examples/device_validation.cpp
@@ -33,11 +33,11 @@ auto get_current_status(device const &d) -> status {
 
 int main(int, char *[]) {
     auto const device_registry = std::vector<device>{
-        {identifier{1}, vendor_identifier{1}, status{status::Idle}},
-        {identifier{2}, vendor_identifier{1}, status{status::Busy}},
-        {identifier{3}, vendor_identifier{2}, status{status::Idle}},
-        {identifier{4}, vendor_identifier{2}, status{status::Busy}},
-        {identifier{5}, vendor_identifier{2}, status{status::Waiting}},
+        {identifier{1}, vendor_identifier{1}, status::Idle},
+        {identifier{2}, vendor_identifier{1}, status::Busy},
+        {identifier{3}, vendor_identifier{2}, status::Idle},
+        {identifier{4}, vendor_identifier{2}, status::Busy},
+        {identifier{5}, vendor_identifier{2}, status::Waiting},
     };
 
     // Given a device d: d.vendor_id == 2 and d.current_status == status::Idle

--- a/include/funktions/predicates.h
+++ b/include/funktions/predicates.h
@@ -53,6 +53,17 @@ constexpr auto gt(T &&value) {
     return fn_wrapper{[v = std::forward<T>(value)](auto &&other) { return std::forward<decltype(other)>(other) > v; }};
 }
 
+/**
+ * Wraps the greater-than operation, such that gt(x)(y) is equivalent to y > x.
+ * @tparam T type of the argument to be checked for comparison.
+ * @param value argument to be checked for comparison.
+ * @return a predicate wrapped in an fn_wrapper that upon evaluation checks if the second argument is greater-than the
+ * first.
+ */
+constexpr auto is_true() {
+    return fn_wrapper{[](auto &&other) { return static_cast<bool>(std::forward<decltype(other)>(other)); }};
+}
+
 }
 
 #endif

--- a/include/funktions/predicates.h
+++ b/include/funktions/predicates.h
@@ -54,14 +54,19 @@ constexpr auto gt(T &&value) {
 }
 
 /**
- * Wraps the greater-than operation, such that gt(x)(y) is equivalent to y > x.
- * @tparam T type of the argument to be checked for comparison.
- * @param value argument to be checked for comparison.
- * @return a predicate wrapped in an fn_wrapper that upon evaluation checks if the second argument is greater-than the
- * first.
+ * Wraps the y == true operation in a curried-form, such that is_true()(y) is equivalent to y == true.
+ * @return a predicate wrapped in an fn_wrapper that upon evaluation checks if the argument is equals to true.
  */
 constexpr auto is_true() {
     return fn_wrapper{[](auto &&other) { return static_cast<bool>(std::forward<decltype(other)>(other)); }};
+}
+
+/**
+ * Wraps the y == false operation in a curried-form, such that is_false()(y) is equivalent to y == false.
+ * @return a predicate wrapped in an fn_wrapper that upon evaluation checks if the argument is equals to false.
+ */
+constexpr auto is_false() {
+    return fn_wrapper{[](auto &&other) { return !static_cast<bool>(std::forward<decltype(other)>(other)); }};
 }
 
 }

--- a/tests/predicates_test.cpp
+++ b/tests/predicates_test.cpp
@@ -46,3 +46,14 @@ TEST_CASE("gt(x)(y) is equivalent to y > x", "[predicates]") {
 
     CHECK(expected == got);
 }
+
+TEST_CASE("is_true()(y) is equivalent to y == true", "[predicates]") {
+    auto const [input, expected] = GENERATE(table<bool, bool>({
+        {true, true},
+        {false, false},
+    }));
+
+    auto const got = is_true()(input);
+
+    CHECK(expected == got);
+}

--- a/tests/predicates_test.cpp
+++ b/tests/predicates_test.cpp
@@ -57,3 +57,14 @@ TEST_CASE("is_true()(y) is equivalent to y == true", "[predicates]") {
 
     CHECK(expected == got);
 }
+
+TEST_CASE("is_false()(y) is equivalent to y == false", "[predicates]") {
+    auto const [input, expected] = GENERATE(table<bool, bool>({
+        {true, false},
+        {false, true},
+    }));
+
+    auto const got = is_false()(input);
+
+    CHECK(expected == got);
+}


### PR DESCRIPTION
* feat: predicates: Introduce is_false()(y) to check whether y == false
    
    This is a curried-form of y == false, meant to be passed to higher-order
    functions, such as STL algorithms.

* feat: predicates: Introduce is_true()(y) to check whether y == true
    
    This is a curried-form of y == true, meant to be passed to higher-order
    functions, such as STL algorithms.

* refactor: examples: Don't use unnecessary enum prefix